### PR TITLE
Remoción de estilo META_STROKE y dependencia coordinatorlayout

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-06T21:43:00.258638400Z">
+        <DropdownSelection timestamp="2025-06-07T00:44:37.199177400Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=320146864723" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
 
     //libreria para las animaaciones
     implementation(libs.lottie) //codigo que agregue, tuve que agregarlo en el archivo libs.versions.toml para poder usar esto aqui
-    implementation(libs.coordinatorlayout)  // Necesario para CoordinatorLayout
 
     implementation(libs.appcompat)
     implementation(libs.material)

--- a/app/src/main/res/layout/activity_dashboard.xml
+++ b/app/src/main/res/layout/activity_dashboard.xml
@@ -28,6 +28,7 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:strokeWidth="0dp"
                 android:layout_marginTop="30dp">
+                
 
                 <LinearLayout
                     style="@style/FONDO_DEGRADADO"
@@ -162,7 +163,8 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             app:cardCornerRadius="12dp"
-                            app:cardElevation="2dp">
+                            app:cardElevation="2dp"
+                            >
 
                             <TextView
                                 android:id="@+id/percentText"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -27,16 +27,13 @@
 
 
     <style name="META">
-        <item name="strokeColor">@color/colorUno_oscuro</item>
         <item name="tint">@color/colorUno_oscuro</item> // Color del ícon
         <item name="indicatorColor">@color/colorUno_oscuro</item>
         <item name="cardBackgroundColor">@color/colorUno_oscuro</item>
         <item name="android:textColor">@color/colorUno_oscuro</item>
     </style>
 
-    <style name="META_STROKE">
-        <item name="strokeColor">@color/colorUno_oscuro</item>
-    </style>
+
 
     <style name="CUADRO_GRID_1">
         <item name="strokeColor">@color/cuadro_grid_1_uno</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -38,9 +38,7 @@
         <item name="android:textColor">@color/primary</item>
     </style>
 
-    <style name="META_STROKE">
-        <item name="strokeColor">@color/primary</item>
-    </style>
+
 
 
     <style name="CUADRO_GRID_1">

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,6 @@ constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayo
 lottie = { group = "com.airbnb.android", name = "lottie", version.ref = "lottie"}
 
 konfetti = { group = "nl.dionsegijn", name = "konfetti", version.ref = "konfetti" }
-coordinatorlayout = { group = "androidx.coordinatorlayout", name = "coordinatorlayout", version.ref = "coordinatorlayout" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Se eliminó el estilo `META_STROKE` de los archivos `themes.xml` y `themes.xml (night)` ya que no se estaba utilizando.

Además, se eliminó la dependencia `coordinatorlayout` del archivo `build.gradle.kts` y `libs.versions.toml` porque no era necesaria para la funcionalidad actual de la aplicación.

Se realizaron ajustes menores en el espaciado del archivo `activity_dashboard.xml`.